### PR TITLE
Fix get_upright_3d_box_corners to correct counter-clockwise

### DIFF
--- a/src/waymo_open_dataset/utils/box_utils.py
+++ b/src/waymo_open_dataset/utils/box_utils.py
@@ -163,8 +163,8 @@ def get_upright_3d_box_corners(boxes, name=None):
     # [N, 8, 3]
     corners = tf.reshape(
         tf.stack([
-            l2, w2, -h2, -l2, w2, -h2, -l2, -w2, -h2, l2, -w2, -h2, l2, w2, h2,
-            -l2, w2, h2, -l2, -w2, h2, l2, -w2, h2
+            l2, w2, -h2, l2, -w2, -h2, -l2, -w2, -h2, -l2, w2, -h2, l2, w2, h2,
+            l2, -w2, h2, -l2, -w2, h2, -l2, w2, h2
         ],
                  axis=-1), [-1, 8, 3])
     # [N, 8, 3]


### PR DESCRIPTION
Previous 3d_box_corners calculation is clockwise; Fix it to correct counter-clockwise, i.e., right top, left top, left bottom, right bottom